### PR TITLE
Added github action to auto publish package on pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Publish package
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+        architecture: 'x64'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - name: Build source and binary distribution package
+      run: |
+        python setup.py sdist bdist_wheel
+      env:
+        PACKAGE_VERSION: ${{ github.ref }}
+
+    - name: Check distribution package
+      run: |
+        twine check dist/*
+    - name: Publish distribution package
+      run: |
+        twine upload dist/*
+      env:
+        TWINE_REPOSITORY: ${{ secrets.PYPI_REPOSITORY }}
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TWINE_NON_INTERACTIVE: yes

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ class PublishCommand(Command):
 
 setup(
     name=NAME,
-    version=about['__version__'],
+    version=os.getenv('PACKAGE_VERSION', '0.0.0').replace('refs/tags/', ''),
     description=DESCRIPTION,
     long_description=long_description,
     author=AUTHOR,


### PR DESCRIPTION
Added GitHub Action Workflow to publish the package on PyPi. The action triggers when a release is drafted on GitHub and uses the GitHub release version as the package version.

The action expects secrets to be configured as follows:

PYPI_REPOSITORY: Either pypi or testpypi.
PYPI_USERNAME: The username (not your name nor your email) at PyPi (or at PyPi Testing).
PYPI_PASSWORD: The password at PyPi (or at PyPi Testing).

--------------------------------------------------------------------------------------------------------------------------------
Auto deploy tested via testpypi as  [updatable 0.4.2](https://test.pypi.org/project/updatable/0.4.2/)