### PR TITLE
Fixes categorized package data for packaging drop of LegacyVersion

### DIFF
--- a/updatable/utils.py
+++ b/updatable/utils.py
@@ -89,13 +89,13 @@ def get_categorized_package_data(package_data, package_version):
     non_semantic_versions = []
 
     for release, info in package_data["releases"].items():
-        parsed_release = parse(release)
-
         upload_time = None
         if info:
             upload_time = datetime.strptime(info[0]["upload_time"], "%Y-%m-%dT%H:%M:%S")
 
         try:
+            parsed_release = parse(release)
+
             # Get semantic version of package
             release_version = semantic_version.Version.coerce(release)
 


### PR DESCRIPTION
This is a fix in order to be compatible with [packaging](https://github.com/pypa/packaging/releases/tag/22.0) and the [drop of LegacyVersion](https://github.com/pypa/packaging/pull/407) introduced in 22.0

Without this fix, the package would have problems parsing releases such as https://pypi.org/project/pytz/2004d/

```
  File "/usr/local/lib/python3.7/site-packages/updatable/utils.py", line 251, in get_package_update_list
    categorized_package_data = get_categorized_package_data(package_data, package_version)
  File "/usr/local/lib/python3.7/site-packages/updatable/utils.py", line 89, in get_categorized_package_data
    parsed_release = parse(release)
  File "/usr/local/lib/python3.7/site-packages/packaging/version.py", line 52, in parse
    return Version(version)
  File "/usr/local/lib/python3.7/site-packages/packaging/version.py", line 197, in __init__
    raise InvalidVersion(f"Invalid version: '{version}'")
packaging.version.InvalidVersion: Invalid version: '2004d'
```
